### PR TITLE
Add case for prelude/into-map for if only coll is provided.

### DIFF
--- a/src/cljc/clj_toolbox/prelude.cljc
+++ b/src/cljc/clj_toolbox/prelude.cljc
@@ -47,7 +47,9 @@
   "
     Transforms coll into a hash-map by using (kf x) as the key and (vf x) as the value for each x in coll
     vf defaults to identity if not provided
+    if only coll is provided, will assume coll is a list of pairs
   "
+  ([coll] (into {} coll))
   ([kf coll]
    (into-map kf identity coll))
   ([kf vf coll]

--- a/test/clj/clj_toolbox/prelude_test.clj
+++ b/test/clj/clj_toolbox/prelude_test.clj
@@ -58,10 +58,17 @@
         
 
 (defntest into-map
+  ;; kf, vf and coll provided
   [:id :val [{:id  :a
               :val :b}
              {:id  :c
-              :val :d}]]  {:a :b :c :d}
+              :val :d}]]  {:a :b, :c :d}
 
-  [inc [0 1]] {1 0 2 1})
+  ;; kf and coll provided
+  [inc [0 1]] {1 0 2 1}
+  [keyword ["a" "b"]] {:a "a", :b "b"}
+  ;; Only coll provided
+  [[]] {} ; empty coll
+  [[[:a :b]]] {:a :b}
+  [[[:a :b] [:c :d]]] {:a :b, :c :d})
 


### PR DESCRIPTION
In this case it will treat the collection as a list of pairs, which is
the same behavior as (into {} coll), so we call that instead of calling
(into-map first second coll) like I originally planned.
